### PR TITLE
0.3.0: tokio="1"; run tests using tarantool docker; `cargo clippy` issues fixed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,27 +24,27 @@ futures-sink = "0.3"
 futures-channel = "0.3"
 futures-util = "0.3"
 futures = "0.3"
-bytes = "0.5"
+bytes = "1"
 log = "0"
 env_logger = "0"
 byteorder = "1.3"
 
-tokio = { version = "0.2", features = ["full"] }
-tokio-util = {version = "0.3", features= ["codec"]}
+tokio = { version = "1", features = ["full"] }
+tokio-util = {version = "0.6", features= ["codec", "time"]}
 
 serde = "1.0"
 serde_derive = "1.0"
 rmp = "0.8"
-rmp-serde = "0.14"
+rmp-serde = "0.15"
 rmp-serialize = "0.8"
 rmpv = { version = "0.4", features = ["with-serde"] }
-base64 = "0.12"
+base64 = "0.13"
 sha1 = "0.6"
 rustc-serialize = "0.3"
 
 [dev-dependencies]
-actix-web = "2"
-actix-rt = "1"
+actix-web = "3"
+actix-rt = "2"
 serde_json = "1.0"
-hyper = "0.13"
+hyper = { version = "0.14", features = ["full"] }
 url = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 repository = "https://github.com/zheludkovm/RustyTarantool"
 categories = ["asynchronous", "network-programming"]
 keywords = ["asynchronous", "tarantool", "protocol" , "api"]
-version = "0.2.10"
+version = "0.3.0"
 exclude = [
     "test-tarantool/*"
 ]

--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ run tarantool
 cd test-tarantool;tarantool init-tarantool.lua
 ```
 
+or via docker
+
+
+```bash
+# in rusty_tarantool dir
+run_tests.sh
+```
 
 Lua stored procedure: 
 ```lua

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ Use tokio.io as base client framework
 [Latest Version]: https://img.shields.io/crates/v/rusty_tarantool.svg
 [crates.io]: https://crates.io/crates/rusty_tarantool
 
+## Run tests via tarantool in docker
+
+```bash
+# in rusty_tarantool dir
+run_tests.sh
+```
 ## Example
 
 Call echo stored procedure
@@ -25,14 +31,6 @@ run tarantool
 
 ```bash
 cd test-tarantool;tarantool init-tarantool.lua
-```
-
-or via docker
-
-
-```bash
-# in rusty_tarantool dir
-run_tests.sh
 ```
 
 Lua stored procedure: 
@@ -85,3 +83,5 @@ hyper http server connecting to tarantool
 actix-web example
 
 simple benchmark
+
+

--- a/examples/hyper-tarantool-proxy.rs
+++ b/examples/hyper-tarantool-proxy.rs
@@ -3,7 +3,7 @@ use serde_derive::{Deserialize, Serialize};
 use std::convert::Infallible;
 
 use hyper::service::{make_service_fn, service_fn};
-use hyper::{header, Body, Method, Request, Response, Server, StatusCode};
+use hyper::{header, server::Server, Body, Method, Request, Response, StatusCode};
 use std::collections::HashMap;
 use std::io;
 use url;

--- a/examples/simple-call.rs
+++ b/examples/simple-call.rs
@@ -9,8 +9,8 @@ async fn main() -> io::Result<()> {
         .set_reconnect_time_ms(2000)
         .build();
 
-    let response = client.call_fn2("test", &("param11", "param12") , &2).await?;
-    let res : ((String,String), u64, Option<u64>) = response.decode_trio()?;
+    let response = client.call_fn2("test", &("param11", "param12"), &2).await?;
+    let res: ((String, String), u64, Option<u64>) = response.decode_trio()?;
     println!("stored procedure response ={:?}", res);
     Ok(())
 }

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set -e
 
 dir=$(dirname "$0")
 cd $dir
@@ -52,7 +51,6 @@ x() {
 	fi
 }
 
-
 will() {
 	echo "${_ansiDarkGray}${_ansiBold}WILL ${_ansiLightGray}$@${_ansiDarkGray} . . .${_ansiReset}"
 }
@@ -80,10 +78,8 @@ while [[ $# -gt 0 ]]; do
 	shift
 done
 
-set +e
 x sudo docker container stop $container
 x sudo docker container rm -f $container
-set -e
 x sudo docker run \
     --name $container \
     -p$port:3301 \

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -e
+
+dir=$(dirname "$0")
+cd $dir
+
+container=rusty_tarantool_test
+port=3301
+user=user
+pass=pass
+init_script=init-tarantool-docker.lua
+data_file=countries.json
+src_dir=$(pwd)/test-tarantool
+dst_dir=/opt/tarantool
+
+_ansiReset=$'\e[0m' # https://superuser.com/questions/33914/why-doesnt-echo-support-e-escape-when-using-the-e-argument-in-macosx/33950#33950
+_ansiBold=$'\e[1m'
+_ansiRed=$'\e[31m'
+_ansiLightGray=$'\e[37m'
+_ansiDarkGray=$'\e[90m'
+_ansiDim=$'\e[2m'
+_ansiGreen=$'\e[32m'
+
+help() {
+	cat <<EOT
+$0 -- run rusty_tarantool tests using tarantool in docker
+USAGE:
+    $0 [ --dry-run ]
+OPTIONS:
+    --dry-run 	just echo commands will be executed
+EOT
+exit 0
+}
+
+err() {
+	echo ${_ansiRed}${_ansiBold}ERR${_ansiReset}: "$@" >&2
+	exit 1
+}
+
+x() {
+	if [[ $dry_run ]]; then
+		echo "${_ansiDarkGray}${_ansiBold}DRY RUN: ${_ansiLightGray}$@${_ansiReset}"
+	else
+		will "$@"
+		"$@"
+		local exitcode=$?
+		if [[ exitcode -eq 0 ]]; then
+			did "$@"
+		else
+			err
+		fi
+	fi
+}
+
+
+will() {
+	echo "${_ansiDarkGray}${_ansiBold}WILL ${_ansiLightGray}$@${_ansiDarkGray} . . .${_ansiReset}"
+}
+
+did() {
+	echo "${_ansiGreen}${_ansiBold}OK: ${_ansiLightGray}$@${_ansiReset}"
+}
+
+dry_run=
+while [[ $# -gt 0 ]]; do
+	case $1 in 
+		--dry-run )
+			dry_run=$1
+		;;
+		--help )
+			help
+		;;
+		-* )
+			err Unexpected opt $1
+		;;
+		* )
+			err Unexpected arg $1
+		;;
+	esac
+	shift
+done
+
+set +e
+x sudo docker container stop $container
+x sudo docker container rm -f $container
+set -e
+x sudo docker run \
+    --name $container \
+    -p$port:3301 \
+    -e TARANTOOL_USER_NAME=$user \
+    -e TARANTOOL_USER_PASSWORD=$pass \
+    -v $src_dir/$init_script:$dst_dir/$init_script \
+    -v $src_dir/$data_file:$dst_dir/$data_file \
+    -v $src_dir/db:$dst_dir/db \
+	-d \
+    tarantool/tarantool tarantool $dst_dir/$init_script
+x cargo test

--- a/src/tarantool/codec.rs
+++ b/src/tarantool/codec.rs
@@ -84,19 +84,21 @@ fn parse_response(
                 sync,
                 Ok(TarantoolResponse::new_full_response(
                     code,
-                    response_fields.remove(&(Key::DATA as u64)).unwrap_or_default(),
+                    response_fields
+                        .remove(&(Key::DATA as u64))
+                        .unwrap_or_default(),
                     response_fields.remove(&(Key::METADATA as u64)),
-                    response_fields.remove(&(Key::SQL_INFO as u64))
-                    // search_key_in_msgpack_map(r, Key::DATA as u64)?,
+                    response_fields.remove(&(Key::SQL_INFO as u64)), // search_key_in_msgpack_map(r, Key::DATA as u64)?,
                 )),
             ))
-        },
+        }
         _ => {
-            let response_data =
-                TarantoolResponse::new_short_response(
-                    code,
-                    response_fields.remove(&(Key::ERROR as u64)).unwrap_or_default()
-                );
+            let response_data = TarantoolResponse::new_short_response(
+                code,
+                response_fields
+                    .remove(&(Key::ERROR as u64))
+                    .unwrap_or_default(),
+            );
             let s: String = response_data.decode()?;
             error!("Tarantool ERROR >> {:?}", s);
             Ok((sync, Err(io::Error::new(io::ErrorKind::Other, s))))
@@ -173,7 +175,10 @@ fn decode_greetings(
     let test = str::from_utf8(&header).map_err(map_err_to_io)?;
 
     let res = match test {
-        GREETINGS_HEADER => Ok(Some((0, Ok(TarantoolResponse::new_short_response(0, Bytes::new()))))),
+        GREETINGS_HEADER => Ok(Some((
+            0,
+            Ok(TarantoolResponse::new_short_response(0, Bytes::new())),
+        ))),
         _ => Err(io::Error::new(io::ErrorKind::Other, "Unknown header!")),
     };
     //    buf.split_to(64 - GREETINGS_HEADER_LENGTH);

--- a/src/tarantool/codec.rs
+++ b/src/tarantool/codec.rs
@@ -1,14 +1,17 @@
-use crate::tarantool::packets::{Code, Key, TarantoolRequest, TarantoolResponse};
-use crate::tarantool::tools::{
-    decode_serde, get_map_value, make_auth_digest, map_err_to_io, parse_msgpack_map,
-    serialize_to_buf_mut, write_u32_to_slice, SafeBytesMutWriter,
+use crate::tarantool::{
+    packets::{Code, Key, TarantoolRequest, TarantoolResponse},
+    tools::{
+        decode_serde, get_map_value, make_auth_digest, map_err_to_io, parse_msgpack_map,
+        serialize_to_buf_mut, write_u32_to_slice, SafeBytesMutWriter,
+    },
 };
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use rmp::encode;
 use rmpv::{self, decode, Value};
-use std::io;
-use std::io::Cursor;
-use std::str;
+use std::{
+    io::{self, Cursor},
+    str,
+};
 use tokio_util::codec::{Decoder, Encoder};
 
 pub type RequestId = u64;

--- a/src/tarantool/dispatch.rs
+++ b/src/tarantool/dispatch.rs
@@ -12,8 +12,9 @@ use futures_channel::oneshot;
 use futures_util::FutureExt;
 
 use tokio::net::TcpStream;
-use tokio::time::{delay_for, delay_queue, DelayQueue, Duration, Instant};
+use tokio::time::{sleep, Duration, Instant};
 use tokio_util::codec::{Decoder, Framed};
+use tokio_util::time::{delay_queue, DelayQueue};
 
 use crate::tarantool::codec::{RequestId, TarantoolCodec, TarantoolFramedRequest};
 use crate::tarantool::packets::{AuthPacket, CommandPacket, TarantoolRequest, TarantoolResponse};
@@ -113,7 +114,7 @@ impl Dispatch {
         Dispatch {
             config,
             command_receiver,
-            is_command_receiver_closed:false,
+            is_command_receiver_closed: false,
             buffered_command: None,
             awaiting_callbacks: HashMap::new(),
             notify_callbacks,
@@ -236,7 +237,7 @@ impl Dispatch {
                 }
 
                 Ok(())
-            },
+            }
             Some(Ok((request_id, Err(e)))) => {
                 debug!("receive command! {} {:?} ", request_id, e);
                 if self.timeout_time_ms.is_some() {
@@ -249,7 +250,7 @@ impl Dispatch {
                 }
 
                 Ok(())
-            },
+            }
             None => Err(io::Error::new(
                 io::ErrorKind::ConnectionAborted,
                 "return none from stream!",
@@ -285,7 +286,7 @@ impl Dispatch {
                     self.set_status(ClientStatus::Disconnected(e.to_string()))
                         .await;
                     self.send_error_to_all(e.to_string());
-                    delay_for(Duration::from_millis(self.config.reconnect_time_ms)).await;
+                    sleep(Duration::from_millis(self.config.reconnect_time_ms)).await;
                 }
             }
 

--- a/src/tarantool/dispatch.rs
+++ b/src/tarantool/dispatch.rs
@@ -1,23 +1,25 @@
+use crate::tarantool::{
+    codec::{RequestId, TarantoolCodec, TarantoolFramedRequest},
+    packets::{AuthPacket, CommandPacket, TarantoolRequest, TarantoolResponse},
+};
 use core::pin::Pin;
-use std::collections::HashMap;
-use std::io;
-use std::string::ToString;
-use std::sync::{Arc, Mutex, RwLock};
-
-use futures::select;
-use futures::stream::StreamExt;
-use futures::SinkExt;
-use futures_channel::mpsc;
-use futures_channel::oneshot;
+use futures::{select, stream::StreamExt, SinkExt};
+use futures_channel::{mpsc, oneshot};
 use futures_util::FutureExt;
-
-use tokio::net::TcpStream;
-use tokio::time::{sleep, Duration, Instant};
-use tokio_util::codec::{Decoder, Framed};
-use tokio_util::time::{delay_queue, DelayQueue};
-
-use crate::tarantool::codec::{RequestId, TarantoolCodec, TarantoolFramedRequest};
-use crate::tarantool::packets::{AuthPacket, CommandPacket, TarantoolRequest, TarantoolResponse};
+use std::{
+    collections::HashMap,
+    io,
+    string::ToString,
+    sync::{Arc, Mutex, RwLock},
+};
+use tokio::{
+    net::TcpStream,
+    time::{sleep, Duration, Instant},
+};
+use tokio_util::{
+    codec::{Decoder, Framed},
+    time::{delay_queue, DelayQueue},
+};
 
 pub type TarantoolFramed = Framed<TcpStream, TarantoolCodec>;
 pub type CallbackSender = oneshot::Sender<io::Result<TarantoolResponse>>;

--- a/src/tarantool/mod.rs
+++ b/src/tarantool/mod.rs
@@ -1,23 +1,23 @@
-pub use crate::tarantool::packets::{
-    CommandPacket, TarantoolRequest, TarantoolResponse, TarantoolSqlResponse,
+use crate::tarantool::dispatch::{
+    CallbackSender, Dispatch, ERROR_CLIENT_DISCONNECTED, ERROR_DISPATCH_THREAD_IS_DEAD,
 };
-pub use crate::tarantool::tools::{serialize_array, serialize_to_vec_u8};
-use futures_channel::mpsc;
-use futures_channel::oneshot;
+pub use crate::tarantool::{
+    dispatch::{ClientConfig, ClientStatus},
+    packets::{CommandPacket, TarantoolRequest, TarantoolResponse, TarantoolSqlResponse},
+    tools::{serialize_array, serialize_to_vec_u8},
+};
+use futures_channel::{mpsc, oneshot};
+use rmpv::Value;
 use serde::Serialize;
-use std::io;
-use std::sync::{Arc, Mutex, RwLock};
+use std::{
+    io,
+    sync::{Arc, Mutex, RwLock},
+};
 
 pub mod codec;
 mod dispatch;
 pub mod packets;
 mod tools;
-
-use crate::tarantool::dispatch::{
-    CallbackSender, Dispatch, ERROR_CLIENT_DISCONNECTED, ERROR_DISPATCH_THREAD_IS_DEAD,
-};
-pub use crate::tarantool::dispatch::{ClientConfig, ClientStatus};
-use rmpv::Value;
 
 impl ClientConfig {
     pub fn build(self) -> Client {

--- a/src/tarantool/mod.rs
+++ b/src/tarantool/mod.rs
@@ -1,5 +1,7 @@
-pub use crate::tarantool::packets::{CommandPacket, TarantoolRequest, TarantoolResponse, TarantoolSqlResponse};
-pub use crate::tarantool::tools::{serialize_to_vec_u8, serialize_array};
+pub use crate::tarantool::packets::{
+    CommandPacket, TarantoolRequest, TarantoolResponse, TarantoolSqlResponse,
+};
+pub use crate::tarantool::tools::{serialize_array, serialize_to_vec_u8};
 use futures_channel::mpsc;
 use futures_channel::oneshot;
 use serde::Serialize;
@@ -25,17 +27,17 @@ impl ClientConfig {
 
 ///iterator types
 pub enum IteratorType {
-    EQ = 0 , // key == x ASC order
-    REQ = 1, // key == x DESC order
-    ALL = 2, // all tuples
-    LT = 3, // key <  x
-    LE = 4, // key <= x
-    GE = 5, // key >= x
-    GT = 6, // key >  x
-    BitsAllSet = 7, // all bits from x are set in key
-    BitsAnySet = 8, // at least one x's bit is set
+    EQ = 0,            // key == x ASC order
+    REQ = 1,           // key == x DESC order
+    ALL = 2,           // all tuples
+    LT = 3,            // key <  x
+    LE = 4,            // key <= x
+    GE = 5,            // key >= x
+    GT = 6,            // key >  x
+    BitsAllSet = 7,    // all bits from x are set in key
+    BitsAnySet = 8,    // at least one x's bit is set
     BitsAllNotSet = 9, // all bits are not set
-    OVERLAPS = 10, // key overlaps x
+    OVERLAPS = 10,     // key overlaps x
     NEIGHBOR = 11,
 }
 
@@ -58,57 +60,63 @@ pub struct Client {
 
 pub trait ExecWithParamaters {
     fn bind_raw(self, param: Vec<u8>) -> io::Result<Self>
-        where Self: std::marker::Sized;
+    where
+        Self: std::marker::Sized;
 
     ///bind named parameter
-    fn bind_named_ref<T : Serialize, T1:Into<String>>(self, name: T1, param: &T) -> io::Result<Self>
-        where Self: std::marker::Sized,
-
+    fn bind_named_ref<T: Serialize, T1: Into<String>>(self, name: T1, param: &T) -> io::Result<Self>
+    where
+        Self: std::marker::Sized,
     {
         let mut name_s = name.into();
-        name_s.insert(0,':');
+        name_s.insert(0, ':');
 
         self.bind_raw(tools::serialize_one_element_map(
             name_s,
-            tools::serialize_to_vec_u8(param)?)?)
+            tools::serialize_to_vec_u8(param)?,
+        )?)
     }
 
     ///bind parameter
-    fn bind_ref<T : Serialize>(self, param: &T) -> io::Result<Self>
-        where Self: std::marker::Sized
+    fn bind_ref<T: Serialize>(self, param: &T) -> io::Result<Self>
+    where
+        Self: std::marker::Sized,
     {
         self.bind_raw(tools::serialize_to_vec_u8(param)?)
     }
 
     ///bind named parameter
-    fn bind_named<T, T1>(self, name: T1,param: T) -> io::Result<Self>
-        where T: Serialize,
-              Self: std::marker::Sized,
-              T1:Into<String>
+    fn bind_named<T, T1>(self, name: T1, param: T) -> io::Result<Self>
+    where
+        T: Serialize,
+        Self: std::marker::Sized,
+        T1: Into<String>,
     {
         self.bind_named_ref(name, &param)
     }
 
-
     ///bind parameter
     fn bind<T>(self, param: T) -> io::Result<Self>
-        where T: Serialize,
-              Self: std::marker::Sized
+    where
+        T: Serialize,
+        Self: std::marker::Sized,
     {
         self.bind_ref(&param)
     }
 
     ///bind null
     fn bind_null(self) -> io::Result<Self>
-        where  Self: std::marker::Sized
+    where
+        Self: std::marker::Sized,
     {
         self.bind_ref(&Value::Nil)
     }
 
     ///bind named null as parameter
     fn bind_named_null<T1>(self, name: T1) -> io::Result<Self>
-        where  Self: std::marker::Sized,
-               T1:Into<String>
+    where
+        Self: std::marker::Sized,
+        T1: Into<String>,
     {
         self.bind_named_ref(name, &Value::Nil)
     }
@@ -117,13 +125,13 @@ pub trait ExecWithParamaters {
 pub struct PreparedSql {
     client: Client,
     sql: String,
-    params: Vec<Vec<u8>>
+    params: Vec<Vec<u8>>,
 }
 
 pub struct PreparedFunctionCall {
     client: Client,
     function: String,
-    params: Vec<Vec<u8>>
+    params: Vec<Vec<u8>>,
 }
 
 impl Client {
@@ -159,12 +167,13 @@ impl Client {
     ///         .execute().await?;
     ///     let rows = response.decode_result_set()?;
     pub fn prepare_sql<T>(&self, sql: T) -> PreparedSql
-        where   T:Into<String>
+    where
+        T: Into<String>,
     {
         PreparedSql {
-            client : self.clone(),
+            client: self.clone(),
             sql: sql.into(),
-            params: vec![]
+            params: vec![],
         }
     }
 
@@ -180,13 +189,14 @@ impl Client {
     ///         .bind(&1)?
     ///         .execute().await?;
     ///     let s: (Vec<String>, u64) = response.decode_pair()?;
-    pub  fn prepare_fn_call<T>(&self, function_name: T) -> PreparedFunctionCall
-     where T:Into<String>
+    pub fn prepare_fn_call<T>(&self, function_name: T) -> PreparedFunctionCall
+    where
+        T: Into<String>,
     {
         PreparedFunctionCall {
-            client : self.clone(),
+            client: self.clone(),
             function: function_name.into(),
-            params: vec![]
+            params: vec![],
         }
     }
 
@@ -518,7 +528,7 @@ impl Client {
     pub async fn eval<T, T1>(&self, expression: T1, args: &T) -> io::Result<TarantoolResponse>
     where
         T: Serialize,
-        T1: Into<String>
+        T1: Into<String>,
     {
         self.send_command(CommandPacket::eval(expression.into(), args).unwrap())
             .await
@@ -533,9 +543,9 @@ impl Client {
     ///
     #[inline(always)]
     pub async fn exec_sql<T, T1>(&self, sql: T1, args: &T) -> io::Result<TarantoolResponse>
-        where
-            T: Serialize,
-            T1: Into<String>
+    where
+        T: Serialize,
+        T1: Into<String>,
     {
         self.send_command(CommandPacket::exec_sql(sql.into().as_str(), args).unwrap())
             .await
@@ -568,19 +578,15 @@ impl Client {
     }
 }
 
-
 impl ExecWithParamaters for PreparedSql {
-
     ///bind raw parameter
-    fn bind_raw(mut self, param: Vec<u8>) -> io::Result<PreparedSql>  {
+    fn bind_raw(mut self, param: Vec<u8>) -> io::Result<PreparedSql> {
         self.params.push(param);
         Ok(self)
     }
 }
 
-
 impl PreparedSql {
-
     ///eval sql expression in tarantool
     ///
     /// # Examples
@@ -592,17 +598,20 @@ impl PreparedSql {
     //         .execute().await?;
     ///
     #[inline(always)]
-    pub async fn execute(self) -> io::Result<TarantoolSqlResponse>
-    {
-        self.client.send_command(CommandPacket::exec_sql_raw(&self.sql.as_str(), serialize_array(&self.params)?).unwrap())
-            .await.map(|val| val.into())
+    pub async fn execute(self) -> io::Result<TarantoolSqlResponse> {
+        self.client
+            .send_command(
+                CommandPacket::exec_sql_raw(&self.sql.as_str(), serialize_array(&self.params)?)
+                    .unwrap(),
+            )
+            .await
+            .map(|val| val.into())
     }
 }
 
 impl ExecWithParamaters for PreparedFunctionCall {
-
     ///bind raw parameter
-    fn bind_raw(mut self, param: Vec<u8>) -> io::Result<PreparedFunctionCall>  {
+    fn bind_raw(mut self, param: Vec<u8>) -> io::Result<PreparedFunctionCall> {
         self.params.push(param);
         Ok(self)
     }
@@ -633,9 +642,12 @@ impl PreparedFunctionCall {
     ///         .execute().await?;
     ///
     #[inline(always)]
-    pub async fn execute(self) -> io::Result<TarantoolResponse>
-    {
-        self.client.send_command(CommandPacket::call_raw(self.function.as_str(), serialize_array(&self.params)?).unwrap())
+    pub async fn execute(self) -> io::Result<TarantoolResponse> {
+        self.client
+            .send_command(
+                CommandPacket::call_raw(self.function.as_str(), serialize_array(&self.params)?)
+                    .unwrap(),
+            )
             .await
     }
 }

--- a/src/tarantool/mod.rs
+++ b/src/tarantool/mod.rs
@@ -394,10 +394,10 @@ impl Client {
     where
         T: Serialize,
     {
-        self.send_command(
-            CommandPacket::select(space, index, key, offset, limit, iterator as i32).unwrap(),
-        )
-        .await
+        trace!("will");
+        let msg = CommandPacket::select(space, index, key, offset, limit, iterator as i32).unwrap();
+        trace!("select: {:?}", msg);
+        self.send_command(msg).await
     }
 
     ///insert tuple to space

--- a/src/tarantool/packets.rs
+++ b/src/tarantool/packets.rs
@@ -1,14 +1,14 @@
 #![allow(non_camel_case_types)]
-use std::io;
-use std::io::Cursor;
-use std::str;
 
 use crate::tarantool::tools;
+use bytes::Bytes;
 use rmpv::Value;
 use serde::{Deserialize, Serialize};
-
-use bytes::Bytes;
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    io::{self, Cursor},
+    str,
+};
 
 /// tarantool auth packet
 #[derive(Debug, Clone)]

--- a/src/tarantool/packets.rs
+++ b/src/tarantool/packets.rs
@@ -170,8 +170,8 @@ impl TarantoolResponse {
         TarantoolResponse {
             code,
             data,
-            sql_info,
             sql_metadata,
+            sql_info,
         }
     }
 
@@ -206,7 +206,7 @@ impl TarantoolResponse {
         T1: Deserialize<'de>,
         T2: Deserialize<'de>,
     {
-        Ok(tools::decode_serde(Cursor::new(self.data))?)
+        tools::decode_serde(Cursor::new(self.data))
     }
 
     ///decode tarantool response to three elements
@@ -221,9 +221,9 @@ impl TarantoolResponse {
     }
 }
 
-impl Into<TarantoolSqlResponse> for TarantoolResponse {
-    fn into(self) -> TarantoolSqlResponse {
-        TarantoolSqlResponse { response: self }
+impl From<TarantoolResponse> for TarantoolSqlResponse {
+    fn from(from: TarantoolResponse) -> Self {
+        Self { response: from }
     }
 }
 

--- a/src/tarantool/packets.rs
+++ b/src/tarantool/packets.rs
@@ -47,7 +47,7 @@ pub struct TarantoolResponse {
 }
 
 pub struct TarantoolSqlResponse {
-   response: TarantoolResponse,
+    response: TarantoolResponse,
 }
 
 pub type UntypedRow = Vec<Value>;
@@ -56,17 +56,18 @@ pub type UntypedRow = Vec<Value>;
 pub enum SqlMetaType {
     boolean,
     integer,
- 	unsigned,
- 	number,
- 	string,
- 	varbinary,
- 	scalar,
-    unknown(String)
+    unsigned,
+    number,
+    string,
+    varbinary,
+    scalar,
+    unknown(String),
 }
 
 impl<'de> Deserialize<'de> for SqlMetaType {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where D: serde::de::Deserializer<'de>
+    where
+        D: serde::de::Deserializer<'de>,
     {
         let s = String::deserialize(deserializer)?;
         Ok(match s.as_str() {
@@ -78,20 +79,20 @@ impl<'de> Deserialize<'de> for SqlMetaType {
             "varbinary" => SqlMetaType::varbinary,
             "scalar" => SqlMetaType::scalar,
 
-            v => SqlMetaType::unknown(String::from( v))
+            v => SqlMetaType::unknown(String::from(v)),
         })
     }
 }
 
 #[derive(Debug, Deserialize, PartialEq)]
-pub struct SqlResultMetadataFieldInfo{
-    name:String,
-    sql_type:SqlMetaType
+pub struct SqlResultMetadataFieldInfo {
+    name: String,
+    sql_type: SqlMetaType,
 }
 
 #[derive(Debug, Deserialize, PartialEq)]
 pub struct SqlResultMetadata {
-    pub fields : Option<Vec<SqlResultMetadataFieldInfo>>,
+    pub fields: Option<Vec<SqlResultMetadataFieldInfo>>,
     pub row_count: Option<u64>,
     pub auto_increment_ids: Option<Vec<u64>>,
 }
@@ -152,11 +153,26 @@ pub enum Key {
 
 impl TarantoolResponse {
     pub fn new_short_response(code: u64, data: Bytes) -> TarantoolResponse {
-        TarantoolResponse { code, data, sql_info: None, sql_metadata: None }
+        TarantoolResponse {
+            code,
+            data,
+            sql_info: None,
+            sql_metadata: None,
+        }
     }
 
-    pub fn new_full_response(code: u64, data: Bytes, sql_metadata: Option<Bytes>, sql_info: Option<Bytes>) -> TarantoolResponse {
-        TarantoolResponse { code, data, sql_info, sql_metadata }
+    pub fn new_full_response(
+        code: u64,
+        data: Bytes,
+        sql_metadata: Option<Bytes>,
+        sql_info: Option<Bytes>,
+    ) -> TarantoolResponse {
+        TarantoolResponse {
+            code,
+            data,
+            sql_info,
+            sql_metadata,
+        }
     }
 
     /// decode tarantool response to any serder deserializable struct
@@ -169,8 +185,8 @@ impl TarantoolResponse {
 
     /// decode tarantool response to any serder deserializable struct
     pub fn decode_result_set<'de, T>(self) -> io::Result<Vec<T>>
-        where
-            T: Deserialize<'de>,
+    where
+        T: Deserialize<'de>,
     {
         tools::decode_serde(Cursor::new(self.data))
     }
@@ -207,17 +223,15 @@ impl TarantoolResponse {
 
 impl Into<TarantoolSqlResponse> for TarantoolResponse {
     fn into(self) -> TarantoolSqlResponse {
-        TarantoolSqlResponse{ response:self}
+        TarantoolSqlResponse { response: self }
     }
 }
 
-
-
-impl  TarantoolSqlResponse {
+impl TarantoolSqlResponse {
     /// decode tarantool response to any serder deserializable struct
     pub fn decode_result_set<'de, T>(self) -> io::Result<Vec<T>>
-        where
-            T: Deserialize<'de>,
+    where
+        T: Deserialize<'de>,
     {
         tools::decode_serde(Cursor::new(self.response.data))
     }
@@ -229,29 +243,32 @@ impl  TarantoolSqlResponse {
 
     ///result set metadata
     pub fn metadata(&self) -> SqlResultMetadata {
-        let sql_info : Option<HashMap<u8, Value>> = tools::decode_serde_optional(&self.response.sql_info);
+        let sql_info: Option<HashMap<u8, Value>> =
+            tools::decode_serde_optional(&self.response.sql_info);
         println!("sql_info={:?}", sql_info);
         let sql_info_fields = sql_info
             .map(|mut info| {
-                (info.remove(&(SqlInfo::SQL_INFO_ROW_COUNT as u8)).and_then(|v|v.as_u64()),
-                 info.remove(&(SqlInfo::SQL_INFO_AUTO_INCREMENT_IDS as u8))
-                     .and_then(|val|val.as_array().map(|arr|{
-                         arr.iter().flat_map(|e|e.as_u64()).collect()
-                     }))
+                (
+                    info.remove(&(SqlInfo::SQL_INFO_ROW_COUNT as u8))
+                        .and_then(|v| v.as_u64()),
+                    info.remove(&(SqlInfo::SQL_INFO_AUTO_INCREMENT_IDS as u8))
+                        .and_then(|val| {
+                            val.as_array()
+                                .map(|arr| arr.iter().flat_map(|e| e.as_u64()).collect())
+                        }),
                 )
-            }).unwrap_or((None, None));
+            })
+            .unwrap_or((None, None));
 
-        let fields : Option<Vec<SqlResultMetadataFieldInfo>> = tools::decode_serde_optional( &self.response.sql_metadata);
+        let fields: Option<Vec<SqlResultMetadataFieldInfo>> =
+            tools::decode_serde_optional(&self.response.sql_metadata);
         SqlResultMetadata {
             fields,
-            row_count:sql_info_fields.0,
-            auto_increment_ids:sql_info_fields.1
+            row_count: sql_info_fields.0,
+            auto_increment_ids: sql_info_fields.1,
         }
     }
-
 }
-
-
 
 impl CommandPacket {
     pub fn call<T>(function: &str, params: &T) -> io::Result<CommandPacket>
@@ -261,8 +278,7 @@ impl CommandPacket {
         CommandPacket::call_raw(function, tools::serialize_to_vec_u8(params)?)
     }
 
-    pub fn call_raw(function: &str, params: Vec<u8>) -> io::Result<CommandPacket>
-    {
+    pub fn call_raw(function: &str, params: Vec<u8>) -> io::Result<CommandPacket> {
         Ok(CommandPacket {
             code: Code::CALL,
             internal_fields: vec![(Key::FUNCTION, Value::from(function))],
@@ -387,14 +403,13 @@ impl CommandPacket {
     }
 
     pub fn exec_sql<T>(sql: &str, args: &T) -> io::Result<CommandPacket>
-        where
-            T: Serialize,
+    where
+        T: Serialize,
     {
         CommandPacket::exec_sql_raw(sql, tools::serialize_to_vec_u8(args)?)
     }
 
-    pub fn exec_sql_raw(sql: &str, args_raw: Vec<u8>) -> io::Result<CommandPacket>
-    {
+    pub fn exec_sql_raw(sql: &str, args_raw: Vec<u8>) -> io::Result<CommandPacket> {
         Ok(CommandPacket {
             code: Code::EXECUTE,
             internal_fields: vec![(Key::SQL_TEXT, Value::from(sql))],

--- a/src/tarantool/tools.rs
+++ b/src/tarantool/tools.rs
@@ -7,9 +7,10 @@ use rmpv::Value;
 use serde::{Deserialize, Serialize};
 use sha1::Sha1;
 use std::collections::HashMap;
-use std::error;
-use std::io;
-use std::io::Cursor;
+use std::{
+    error,
+    io::{self, Cursor},
+};
 
 pub fn decode_serde_optional<'de, T>(data: &Option<Bytes>) -> Option<T>
 where

--- a/test-tarantool/init-tarantool-docker.lua
+++ b/test-tarantool/init-tarantool-docker.lua
@@ -1,0 +1,229 @@
+#! /usr/bin/tarantool
+-- This is default tarantool initialization file
+-- with easy to use configuration examples including
+-- replication, sharding and all major features
+-- Complete documentation available in:  http://tarantool.org/doc/
+--
+-- To start this instance please run `systemctl start tarantool@example` or
+-- use init scripts provided by binary packages.
+-- To connect to the instance, use "sudo tarantoolctl enter example"
+-- Features:
+-- 1. Database configuration
+-- 2. Binary logging and snapshots
+-- 3. Replication
+-- 4. Automatinc sharding
+-- 5. Message queue
+-- 6. Data expiration
+
+-----------------
+-- Configuration
+-----------------
+box.cfg {
+    ------------------------
+    -- Network configuration
+    ------------------------
+
+    -- The read/write data port number or URI
+    -- Has no default value, so must be specified if
+    -- connections will occur from remote clients
+    -- that do not use “admin address”
+    listen = 3301;
+    -- listen = '*:3301';
+
+    -- The server is considered to be a Tarantool replica
+    -- it will try to connect to the master
+    -- which replication_source specifies with a URI
+    -- for example konstantin:secret_password@tarantool.org:3301
+    -- by default username is "guest"
+    -- replication_source="127.0.0.1:3102";
+
+    -- The server will sleep for io_collect_interval seconds
+    -- between iterations of the event loop
+    io_collect_interval = nil;
+
+    -- The size of the read-ahead buffer associated with a client connection
+    readahead = 16320;
+
+    ----------------------
+    -- Memtx configuration
+    ----------------------
+
+    -- An absolute path to directory where snapshot (.snap) files are stored.
+    -- If not specified, defaults to /var/lib/tarantool/INSTANCE
+    -- memtx_dir = nil;
+
+    -- How much memory Memtx engine allocates
+    -- to actually store tuples, in bytes.
+    memtx_memory = 128 * 1024 * 1024;
+
+    -- Size of the smallest allocation unit, in bytes.
+    -- It can be tuned up if most of the tuples are not so small
+    memtx_min_tuple_size = 16;
+
+    -- Size of the largest allocation unit, in bytes.
+    -- It can be tuned up if it is necessary to store large tuples
+    memtx_max_tuple_size = 10 * 1024 * 1024; -- 10Mb
+    vinyl_max_tuple_size = 10 * 1024 * 1024; -- 10Mb
+
+    ----------------------
+    -- Vinyl configuration
+    ----------------------
+
+    -- An absolute path to directory where Vinyl files are stored.
+    -- If not specified, defaults to /var/lib/tarantool/INSTANCE
+    -- vinyl_dir = nil;
+
+    -- How much memory Vinyl engine can use for in-memory level, in bytes.
+    vinyl_memory = 128 * 1024 * 1024; -- 128 mb
+
+    -- How much memory Vinyl engine can use for caches, in bytes.
+    vinyl_cache = 64 * 1024 * 1024; -- 64 mb
+
+    -- The maximum number of background workers for compaction.
+    vinyl_write_threads = 2;
+
+    ------------------------------
+    -- Binary logging and recovery
+    ------------------------------
+
+    -- An absolute path to directory where write-ahead log (.xlog) files are
+    -- stored. If not specified, defaults to /var/lib/tarantool/INSTANCE
+    -- wal_dir = nil;
+
+    -- Specify fiber-WAL-disk synchronization mode as:
+    -- "none": write-ahead log is not maintained;
+    -- "write": fibers wait for their data to be written to the write-ahead log;
+    -- "fsync": fibers wait for their data, fsync follows each write;
+    --    wal_mode = "none";
+    wal_mode = "write";
+
+    -- The maximal size of a single write-ahead log file
+    wal_max_size = 256 * 1024 * 1024;
+
+    -- The interval between actions by the snapshot daemon, in seconds
+    checkpoint_interval = 60 * 60; -- one hour
+
+    -- The maximum number of snapshots that the snapshot daemon maintans
+    checkpoint_count = 6;
+
+    -- Reduce the throttling effect of box.snapshot() on
+    -- INSERT/UPDATE/DELETE performance by setting a limit
+    -- on how many megabytes per second it can write to disk
+    snap_io_rate_limit = nil;
+
+    -- Don't abort recovery if there is an error while reading
+    -- files from the disk at server start.
+    force_recovery = true;
+
+    ----------
+    -- Logging
+    ----------
+
+    -- How verbose the logging is. There are six log verbosity classes:
+    -- 1 – SYSERROR
+    -- 2 – ERROR
+    -- 3 – CRITICAL
+    -- 4 – WARNING
+    -- 5 – INFO
+    -- 6 – DEBUG
+    log_level = 5;
+
+    -- By default, the log is sent to /var/log/tarantool/INSTANCE.log
+    -- If logger is specified, the log is sent to the file named in the string
+    -- log = "./tarantool.log",
+    -- wal_dir = './db/wal',
+    -- memtx_dir = './db/memtx',
+    -- vinyl_dir = './db/vinyl',
+    --work_dir = './work',
+
+    -- If true, tarantool does not block on the log file descriptor
+    -- when it’s not ready for write, and drops the message instead
+    --log_nonblock = true;
+
+    -- If processing a request takes longer than
+    -- the given value (in seconds), warn about it in the log
+    too_long_threshold = 0.5;
+
+    -- Inject the given string into server process title
+    -- custom_proc_title = 'example';
+    background = false;
+    pid_file = 'rust.pid';
+}
+
+local function bootstrap()
+    box.schema.user.grant('guest', 'read,write,execute', 'universe')
+
+    box.schema.user.create('rust', { password = 'rust' })
+    box.schema.user.grant('rust', 'read,write,execute', 'universe')
+end
+box.once('grants2', bootstrap)
+local json = require('json')
+local log = require('log')
+local open = io.open
+
+local function init_spaces()
+    if(box.space.target_space ~=nil) then
+       box.space.target_space:drop();
+    end
+
+    box.schema.create_space('target_space', {id = 1000})
+    box.space.target_space:create_index('primary', {type='tree', parts={1,'unsigned', 2, "string"}})
+    box.space.target_space:put({1,'test-row'})
+    box.space.target_space:put({2,'test-row2'})
+
+    --init table with currenies
+    if(box.space.countries ~=nil) then
+        box.space.countries:drop();
+    end
+
+    local countriesSpace = box.schema.create_space('countries', {id = 1001})
+    countriesSpace:create_index('primary', {type='tree', parts={1,'unsigned'}})
+
+    local file = open("/opt/tarantool/countries.json", "rb") -- r read mode and b binary mode
+    local content = file:read "*a"
+    file:close()
+    local currencies = json.decode(content);
+    for i,row in pairs(currencies) do
+       countriesSpace:insert({
+           row["country-code"],
+           string.lower(row["name"]),
+           string.lower(row["region"]),
+           string.lower(row["sub-region"]),
+       })
+    end
+
+end
+
+init_spaces()
+box.execute("drop TABLE1")
+box.execute("CREATE TABLE table1 (column1 INTEGER PRIMARY KEY autoincrement, column2 VARCHAR(100))")
+box.execute("insert into TABLE1 values(1,'1')")
+
+json=require('json')
+fiber = require('fiber')
+function test(a,b)
+--   fiber.sleep(2)
+   return a,b,11
+end
+
+local function check_attr(value, search_str)
+   return  search_str==nil or string.find(value,  string.lower(search_str));
+end
+
+function test_search(country_name, region, sub_region)
+    local result = {};
+    for i,row in box.space.countries:pairs() do
+       if( check_attr(row[2], country_name) and
+           check_attr(row[3], region) and
+           check_attr(row[4], sub_region) ) then
+
+           table.insert(result,{
+              ["country-code"]=row[1],
+              ["name"]=row[2],
+              ["region"]=row[3],
+              ["sub-region"]=row[4],
+           })
+       end
+    end
+    return result;
+end

--- a/tests/test_service.rs
+++ b/tests/test_service.rs
@@ -10,11 +10,13 @@ extern crate rmpv;
 extern crate serde;
 
 use rusty_tarantool::tarantool::packets::{CommandPacket, TarantoolSqlResponse, UntypedRow};
-use rusty_tarantool::tarantool::{serialize_to_vec_u8, Client, ClientConfig, IteratorType, ExecWithParamaters};
+use rusty_tarantool::tarantool::{
+    serialize_to_vec_u8, Client, ClientConfig, ExecWithParamaters, IteratorType,
+};
 
+use rmpv::Value;
 use std::io;
 use std::sync::Once;
-use rmpv::Value;
 
 static INIT: Once = Once::new();
 
@@ -65,7 +67,8 @@ async fn test_call_fn_args() -> io::Result<()> {
         .prepare_fn_call("test")
         .bind_ref(&("aa", "aa"))?
         .bind(1)?
-        .execute().await?;
+        .execute()
+        .await?;
     let s: (Vec<String>, u64) = response.decode_pair()?;
     println!("resp value={:?}", s);
     assert_eq!((vec!["aa".to_string(), "aa".to_string()], 1), s);
@@ -76,7 +79,9 @@ async fn test_call_fn_args() -> io::Result<()> {
 async fn test_select() -> io::Result<()> {
     let client = init_client();
     let key = (1,);
-    let response = client.select(SPACE_ID, 0, &key, 0, 100, IteratorType::EQ).await?;
+    let response = client
+        .select(SPACE_ID, 0, &key, 0, 100, IteratorType::EQ)
+        .await?;
     println!("response2: {:?}", response);
     let s: Vec<(u32, String)> = response.decode()?;
     println!("resp value={:?}", s);
@@ -108,7 +113,7 @@ async fn test_error() -> io::Result<()> {
     println!("response={:?}", response);
     match response {
         Err(_) => {}
-        _ => assert!(false)
+        _ => assert!(false),
     }
     client.delete(SPACE_ID, &tuple).await?;
     // assert_eq!(Err(io::Error::new(io::ErrorKind::Other, "Duplicate key exists in unique index \'primary\' in space \'target_space\'")),
@@ -186,10 +191,12 @@ async fn test_eval() -> io::Result<()> {
 async fn test_sql() -> io::Result<()> {
     let client = init_client();
 
-    let response = client.exec_sql("select * from TABLE1 where COLUMN1=?", &(1,)).await?;
+    let response = client
+        .exec_sql("select * from TABLE1 where COLUMN1=?", &(1,))
+        .await?;
     let row: Vec<(u32, String)> = response.decode()?;
     println!("resp value={:?}", row);
-    assert_eq!(row, vec![(1,"1".to_string())]);
+    assert_eq!(row, vec![(1, "1".to_string())]);
     Ok(())
 }
 
@@ -197,17 +204,18 @@ async fn test_sql() -> io::Result<()> {
 async fn test_sql_bind() -> io::Result<()> {
     let client = init_client();
 
-    let response : TarantoolSqlResponse = client
+    let response: TarantoolSqlResponse = client
         .prepare_sql("select *, true, 1.1, :r from TABLE1 where COLUMN1=:col")
         .bind_named_null("r")?
         .bind_named_ref("col", &1)?
-        .execute().await?;
+        .execute()
+        .await?;
     let meta = response.metadata();
     let rows: Vec<(u32, String, bool, f32, Option<String>)> = response.decode_result_set()?;
 
     println!("resp value={:?}", rows);
     println!("metadata={:?}", meta);
-    assert_eq!(rows, vec![(1,"1".to_string(), true, 1.1, Option::None)]);
+    assert_eq!(rows, vec![(1, "1".to_string(), true, 1.1, Option::None)]);
     Ok(())
 }
 
@@ -215,10 +223,11 @@ async fn test_sql_bind() -> io::Result<()> {
 async fn test_sql_update() -> io::Result<()> {
     let client = init_client();
 
-    let response : TarantoolSqlResponse = client
+    let response: TarantoolSqlResponse = client
         .prepare_sql("UPDATE TABLE1 set column2='1' where column1=?")
         .bind(1)?
-        .execute().await?;
+        .execute()
+        .await?;
     let meta = response.metadata();
     println!("metadata={:?}", meta);
     assert_eq!(meta.row_count, Some(1));
@@ -228,9 +237,10 @@ async fn test_sql_update() -> io::Result<()> {
 async fn test_sql_autoincrement() -> io::Result<()> {
     let client = init_client();
 
-    let response : TarantoolSqlResponse = client
+    let response: TarantoolSqlResponse = client
         .prepare_sql("insert into TABLE1 values(NULL,'2')")
-        .execute().await?;
+        .execute()
+        .await?;
     let meta = response.metadata();
     println!("metadata={:?}", meta);
     assert_eq!(meta.row_count, Some(1));
@@ -242,16 +252,25 @@ async fn test_sql_autoincrement() -> io::Result<()> {
 async fn test_untyped_decode_sql_result() -> io::Result<()> {
     let client = init_client();
 
-    let response : TarantoolSqlResponse = client
+    let response: TarantoolSqlResponse = client
         .prepare_sql("select *, true, 1.1 from TABLE1 where COLUMN1=?")
         .bind_ref(&1)?
-        .execute().await?;
+        .execute()
+        .await?;
     let meta = response.metadata();
     let rows: Vec<UntypedRow> = response.decode_untyped_result_set()?;
 
     println!("resp value={:?}", rows);
     println!("metadata={:?}", meta);
-    assert_eq!(rows, vec![vec![Value::from(1), Value::from("1"), Value::from(true), Value::from(1.1) ]]);
+    assert_eq!(
+        rows,
+        vec![vec![
+            Value::from(1),
+            Value::from("1"),
+            Value::from(true),
+            Value::from(1.1)
+        ]]
+    );
     Ok(())
 }
 

--- a/tests/test_service.rs
+++ b/tests/test_service.rs
@@ -9,14 +9,12 @@ extern crate rmp_serde;
 extern crate rmpv;
 extern crate serde;
 
-use rusty_tarantool::tarantool::packets::{CommandPacket, TarantoolSqlResponse, UntypedRow};
+use rmpv::Value;
 use rusty_tarantool::tarantool::{
+    packets::{CommandPacket, TarantoolSqlResponse, UntypedRow},
     serialize_to_vec_u8, Client, ClientConfig, ExecWithParamaters, IteratorType,
 };
-
-use rmpv::Value;
-use std::io;
-use std::sync::Once;
+use std::{io, sync::Once};
 
 static INIT: Once = Once::new();
 

--- a/tests/test_service.rs
+++ b/tests/test_service.rs
@@ -190,7 +190,6 @@ async fn test_eval() -> io::Result<()> {
 #[tokio::test]
 async fn test_sql() -> io::Result<()> {
     let client = init_client();
-
     let response = client
         .exec_sql("select * from TABLE1 where COLUMN1=?", &(1,))
         .await?;
@@ -233,6 +232,7 @@ async fn test_sql_update() -> io::Result<()> {
     assert_eq!(meta.row_count, Some(1));
     Ok(())
 }
+
 #[tokio::test]
 async fn test_sql_autoincrement() -> io::Result<()> {
     let client = init_client();
@@ -278,10 +278,12 @@ async fn test_untyped_decode_sql_result() -> io::Result<()> {
 // async fn test_prepare_stmt() -> io::Result<()> {
 //     let client = init_client();
 //
-//     let response = client.prepare_stmt("select * from TABLE1 where COLUMN1=?".to_string()).await?;
+//     let response = client
+//         .prepare_stmt("select * from TABLE1 where COLUMN1=?".to_string())
+//         .await?;
 //     let row: Vec<(u32, String)> = response.decode()?;
 //     println!("resp value={:?}", row);
-//     assert_eq!(row, vec![(1,"1".to_string())]);
+//     assert_eq!(row, vec![(1, "1".to_string())]);
 //     Ok(())
 // }
 

--- a/tests/test_transport_call.rs
+++ b/tests/test_transport_call.rs
@@ -17,7 +17,7 @@ use std::io;
 use tokio::net::TcpStream;
 use tokio_util::codec::Decoder;
 
-use crate::tokio::stream::StreamExt;
+use futures::stream::StreamExt;
 
 #[tokio::test]
 async fn test() -> io::Result<()> {

--- a/tests/test_transport_call.rs
+++ b/tests/test_transport_call.rs
@@ -9,15 +9,15 @@ extern crate rmp_serde;
 extern crate rmpv;
 extern crate serde;
 
-use rusty_tarantool::tarantool::codec::TarantoolCodec;
-use rusty_tarantool::tarantool::packets::{AuthPacket, CommandPacket, TarantoolRequest};
+use rusty_tarantool::tarantool::{
+    codec::TarantoolCodec,
+    packets::{AuthPacket, CommandPacket, TarantoolRequest},
+};
 
-use futures::SinkExt;
+use futures::{stream::StreamExt, SinkExt};
 use std::io;
 use tokio::net::TcpStream;
 use tokio_util::codec::Decoder;
-
-use futures::stream::StreamExt;
 
 #[tokio::test]
 async fn test() -> io::Result<()> {


### PR DESCRIPTION
- updated Cargo.toml (major change: tokio="0.2" => tokio="1")
- added run_tests.sh to run rusty_tarantool tests using tarantool docker (no need to install tarantool)
- cargo clippy issues fixed
- incremented version: 0.2.10 => 0.3.0 (due to tokio="1")